### PR TITLE
restore all.sitename config

### DIFF
--- a/code/manifests/config.pp
+++ b/code/manifests/config.pp
@@ -5,7 +5,8 @@ class xrootd::config (
 
   $configdir = $xrootd::params::configdir,
   $logdir = $xrootd::params::logdir,
-
+  $all_sitename = $xrootd::params::all_sitename,
+  
 ) inherits xrootd::params {
 
   include fetchcrl


### PR DESCRIPTION
reintroduce a class param that disappeared and made all.sitename disappear from xrootd config
