### PR TITLE
Made needed changes to use for US_CMS_FNAL_T1 xrootd site and regional redirectors

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class xrootd::config (
   }
 
   file {$configdir:
-    ensure	=> directory,
+    ensure => directory,
     owner  => $xrootd_user,
     group  => $xrootd_group
   }

--- a/manifests/create_config.pp
+++ b/manifests/create_config.pp
@@ -24,9 +24,14 @@ define xrootd::create_config (
   $xrootd_export = $xrootd::config::xrootd_export,
   $xrootd_seclib = $xrootd::config::xrootd_seclib,
   $xrootd_async = $xrootd::config::xrootd_async,
+  $xrootd_monitor = $xrootd::config::xrootd_monitor,
+  $xrootd_chksum = $xrootd::config::xrootd_chksum,
+  $xrootd_fslib = $xrootd::config::xrootd_fslib,
 
   $xrd_port = $xrootd::config::xrd_port,
   $xrd_network = $xrootd::config::xrd_network,
+  $xrd_report = $xrootd::config::xrd_report,
+  $xrd_timeout = $xrootd::config::xrd_timeout,
 
   $acc_authdb = $xrootd::config::acc_authdb,
 
@@ -36,10 +41,20 @@ define xrootd::create_config (
   # ofs.osslib for exec xrootd/cmsd
   $xrd_ofsosslib = $xrootd::config::xrd_ofsosslib,
   $cmsd_ofsosslib = $xrootd::config::cmsd_ofsosslib,
+  $cms_allow = $xrootd::config::cms_allow,
+  $cms_delay = $xrootd::config::cms_delay,
+  $cms_fxhold = $xrootd::config::cms_fxhold,
+  $cms_sched = $xrootd::config::cms_sched,
+  $cms_ping = $xrootd::config::cms_ping,
+  $xrd_sched = $xrootd::config::xrd_sched,
   $ofs_cmslib = $xrootd::config::ofs_cmslib,
   $ofs_forward = $xrootd::config::ofs_forward,
   $ofs_tpc = $xrootd::config::ofs_tpc,
   $oss_localroot = $xrootd::config::oss_localroot,
+  $oss_defaults = $xrootd::config::oss_defaults,
+  $osscachepath = $xrootd::config::osscachepath,
+  $oss_usage = $xrootd::config::oss_usage,
+  $oss_namelib = $xrootd::config::oss_namelib,
 
   $sec_protocol = $xrootd::config::sec_protocol,
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,10 +3,10 @@ class xrootd::params {
     $xrootd_user = "xrootd"
     $xrootd_group = "xrootd"
 
-    $xrootd_instances_options = { "default" => "-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-clustered.cfg -k 7" }
-    $cmsd_instances_options = undef #{ "default" => "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-clustered.cfg -k 7" }
-    $purd_instances_options = undef #{ "default" => "-l /var/log/xrootd/purd.log -c /etc/xrootd/xrootd-clustered.cfg -k 7" }
-    $xfrd_instances_options = undef #{ "default" => "-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-clustered.cfg -k 7" }
+    $xrootd_instances_options = { "default" => "-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+    $cmsd_instances_options = undef #{ "default" => "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+    $purd_instances_options = undef #{ "default" => "-l /var/log/xrootd/purd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+    $xfrd_instances_options = undef #{ "default" => "-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
 
     $exports = undef
 
@@ -40,6 +40,7 @@ class xrootd::params {
     $xrootd_async = false
     $xrootd_chksum = undef
     $xrootd_monitor = undef
+    $xrootd_fslib = undef
 
     $sec_protocol = [ ] 
 
@@ -47,6 +48,7 @@ class xrootd::params {
     #$xrd_network = "nodnr"
     $xrd_network = undef
     $xrd_report = undef
+    $xrd_timeout = undef
     $xrd_maxredirectcount = 1
 
     $acc_authdb = undef
@@ -57,6 +59,11 @@ class xrootd::params {
     # ofs.osslib for exec xrootd/cmsd
     $xrd_ofsosslib = undef
     $cmsd_ofsosslib = undef
+    $cms_allow = undef
+    $cms_fxhold = '60s'
+    $cms_delay = undef
+    $cms_sched = undef
+    $cms_ping = undef
     $ofs_cmslib = undef
     $ofs_forward = undef
     $ofs_tpc = undef
@@ -65,5 +72,9 @@ class xrootd::params {
     $pss_setopt = undef
 
     $oss_localroot = undef
+    $oss_defaults = undef
+    $oss_usage = undef
+    $oss_namelib = undef
+    $osscachepath = undef
 
 }

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -22,18 +22,20 @@ XROOTD_GROUP=<%= @xrootd_group %>
 #            without whitespaces is valid
 #-------------------------------------------------------------------------------
 <% if @xrootd_instances_options -%>
-<% @xrootd_instances_options.map do |option_type| -%>
-<% option_type.sort.map do |instance, options| -%>
+<% @xrootd_instances_options.sort.map do |instance, options| -%>
 XROOTD_<%= instance.upcase %>_OPTIONS="<%= options %>"
-<% end -%><% end -%><% end -%>
+<% end -%><% end -%>
+
 <% if @cmsd_instances_options -%>
 <% @cmsd_instances_options.sort.map do |instance, options| -%>
 CMSD_<%= instance.upcase %>_OPTIONS="<%= options %>"
 <% end -%><% end -%>
+
 <% if @purd_instances_options -%>
 <% @purd_instances_options.sort.map do |instance, options| -%>
 PURD_<%= instance.upcase %>_OPTIONS="<%= options %>"
 <% end -%><% end -%>
+
 <% if @xfrd_instances_options -%>
 <% @xfrd_instances_options.sort.map do |instance, options| -%>
 XFRD_<%= instance.upcase %>_OPTIONS="<%= options %>"
@@ -46,20 +48,22 @@ XFRD_<%= instance.upcase %>_OPTIONS="<%= options %>"
 #-------------------------------------------------------------------------------
 <% if @xrootd_instances_options -%>
 XROOTD_INSTANCES="<% -%>
-<% @xrootd_instances_options.map do |option_type| -%>
-<% option_type.sort.map do |instance, options| -%>
+<% @xrootd_instances_options.sort.map do |instance, options| -%>
   <%= instance -%>
-<% end -%><% end -%>"<% end %>
+<% end -%>"<% end %>
+
 <% if @cmsd_instances_options -%>
 CMSD_INSTANCES="<% -%>
 <% @cmsd_instances_options.sort.map do |instance, options| -%>
   <%= instance -%>
 <% end -%>"<% end %>
+
 <% if @purd_instances_options -%>
 PURD_INSTANCES="<% -%>
 <% @purd_instances_options.sort.map do |instance, options| -%>
   <%= instance -%>
 <% end -%>"<% end %>
+
 <% if @xfrd_instances_options -%>
 XFRD_INSTANCES="<% -%>
 <% @xfrd_instances_options.sort.map do |instance, options| -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -24,6 +24,20 @@ all.sitename <%= @all_sitename %>
 <% if @oss_localroot -%>
 oss.localroot <%= @oss_localroot %>
 <% end -%>
+<% if @oss_defaults -%>
+oss.defaults <%= @oss_defaults %>
+<% end -%>
+<% if @oss_namelib -%>
+oss.namelib <%= @oss_namelib %>
+<% end -%>
+<% if @oss_usage -%>
+oss.usage <%= @oss_usage %>
+<% end -%>
+
+<% if @xrootd_fslib -%>
+xrootd.fslib <%= @xrootd_fslib %>
+<% end -%>
+
 <% if @all_export -%>
 <% @all_export.sort.each do |export| -%>
 all.export <%= File.join(export,"") %>
@@ -33,85 +47,109 @@ all.export <%= File.join(export,"") %>
 xrd.network <%= @xrd_network %>
 <% end -%>
 
-<% if @oss_localroot -%>
-oss.localroot <%= @oss_localroot %>
-<% end -%>
-
 <% if @xrootd_chksum -%>
 xrootd.chksum <%= @xrootd_chksum %>
 <% end -%>
 <% if @xrootd_monitor -%>
 xrootd.monitor <%= @xrootd_monitor %>
 <% end -%>
+<% if @xrd_report -%>
+xrd.report <%= @xrd_report %>
+<% end -%>
+
 <% if @xrootd_async -%>
 xrootd.async <%= @xrootd_async %>
 <% end -%>
 
 if exec xrootd
-xrootd.seclib <%= @xrootd_seclib %>
+<% if @xrootd_seclib -%>
+ xrootd.seclib <%= @xrootd_seclib %>
+<% end -%>
 <% if @sec_protocol -%>
 <% @sec_protocol.sort.each do |secprot| -%>
-sec.protocol <%= secprot %>
+ sec.protocol <%= secprot %>
 <% end -%>
 <% end -%>
 <% if @xrootd_redirect -%>
-xrootd.redirect <%= @xrootd_redirect %>
+ xrootd.redirect <%= @xrootd_redirect %>
 <% end -%>
 <% if @xrootd_export -%>
 <% @xrootd_export.sort.each do |export| -%>
-xrootd.export <%= File.join(export,"") %>
+ xrootd.export <%= export %>
 <% end -%>
 <% end -%>
 <% if @xrd_port -%>
-xrd.port <%= @xrd_port %>
+ xrd.port <%= @xrd_port %>
 <% end -%>
-<% if @xrd_report -%>
-xrd.report <%= @xrd_report %>
+<% if @xrd_timeout -%>
+ xrd.timeout <%= @xrd_timeout %>
 <% end -%>
 <% if @ofs_cmslib -%>
-ofs.cmslib <%= @ofs_cmslib %>
+ ofs.cmslib <%= @ofs_cmslib %>
 <% end -%>
 <% if @xrd_ofsosslib -%>
-ofs.osslib <%= @xrd_ofsosslib %>
+ ofs.osslib <%= @xrd_ofsosslib %>
 <% end -%>
 <% if @ofs_authlib -%>
-ofs.authlib <%= @ofs_authlib %>
+ ofs.authlib <%= @ofs_authlib %>
 <% end -%>
 <% if @ofs_authorize -%>
-ofs.authorize
+ ofs.authorize
 <% end -%>
 <% if @ofs_forward -%>
-ofs.forward <%= @ofs_forward %>
+ ofs.forward <%= @ofs_forward %>
 <% end -%>
 <% if @ofs_persist -%>
-ofs.persist <%= @ofs_persist %>
+ ofs.persist <%= @ofs_persist %>
 <% end -%>
 <% if @ofs_tpc -%>
-ofs.tpc <%= @ofs_tpc %>
+ ofs.tpc <%= @ofs_tpc %>
 <% end -%>
 <% if @acc_authdb -%>
-acc.authdb <%= @acc_authdb %>
+ acc.authdb <%= @acc_authdb %>
 <% end -%>
-all.role <%= @xrd_allrole %>
+ all.role <%= @xrd_allrole %>
+<% if @xrd_sched -%>
+ xrd.sched <%= @xrd_sched %>
+<% end -%> 
 fi
 
 if exec cmsd
 <% if @cmsd_ofsosslib -%>
-ofs.osslib <%= @cmsd_ofsosslib %>
+ ofs.osslib <%= @cmsd_ofsosslib %>
 <% end -%>
 <% if @pss_origin -%>
-pss.origin <%= @pss_origin %>
+ pss.origin <%= @pss_origin %>
 <% end -%>
 <% if @pss_setopt -%>
 <% @pss_setopt.sort.each do |option| -%>
-pss.setopt <%= option %>
+ pss.setopt <%= option %>
 <% end -%>
 <% end -%>
-all.role <%= @cmsd_allrole %>
+ all.role <%= @cmsd_allrole %>
+<% if @cms_allow -%>
+<% @cms_allow.sort.each do |allow| -%>
+ cms.allow <%= allow %>
+<% end -%>
+<% end -%>
+<% if @cms_delay -%>
+ cms.delay <%= @cms_delay %>
+<% end -%> 
+<% if @cms_sched -%>
+ cms.sched <%= @cms_sched %>
+<% end -%> 
+<% if @cms_fxhold -%>
+ cms.fxhold <%= @cms_fxhold %>
+<% end -%>
+<% if @cms_ping -%>
+ cms.ping <%= @cms_ping %>
+<% end -%>
 fi
 
 <% if @all_manager -%>
-all.manager <%= @all_manager %>
+<% @all_manager.sort.each do |manager| -%>
+all.manager <%= manager %>
+<% end -%>
 <% end -%>
 
 <% if @specifics -%>


### PR DESCRIPTION
Added some more config variables, instances_options now have -k fifo like default xrootd RPM, template xrootd.cfg.erb xrootd_instances_options array fixed and idented template content, all.manager converted in an array. Removed duplicated oss.localroot entry in xrootd.xfg.erb