### PR TITLE
Puppet4 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@
 class xrootd (
 ) inherits xrootd::params {
 
-  Class[Xrootd::Install] -> Class[Xrootd::Config] -> Class[Xrootd::Service]
+  Class[xrootd::install] -> Class[xrootd::config] -> Class[xrootd::service]
 
   class{"xrootd::install":}
   class{"xrootd::config":}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 class xrootd::install (
 ) inherits xrootd::params {
 
-  Class[Xrootd::Install] -> Class[Xrootd::Config]
+  Class[xrootd::install] -> Class[xrootd::config]
 
     package {"xrootd":
       ensure => present

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,7 @@ class xrootd::service (
     $authfile = undef
 ) inherits xrootd::params {
 
-  Class[Xrootd::Config] -> Class[Xrootd::Service]
+  Class[xrootd::config] -> Class[xrootd::service]
 
   if $authfile != undef {
     $files = File[$sysconfigfile, $configfile, $authfile]

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -154,7 +154,7 @@ fi
 <% end -%>
 
 <% if @all_manager -%>
-<% @all_manager.sort.each do |manager| -%>
+<% Array(@all_manager).sort.each do |manager| -%>
 all.manager <%= manager %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Fix puppet4 references.
Also fix a case where the erb template is trying to loop on a string : this works in puppet3, but shokes in puppet4. A fix, which is to use Array() in the erb, may have to be applied in many other templates unless there is a check on the parameters type in puppet using something like validate_array()