### PR TITLE
Puppet 4 fix

### DIFF
--- a/manifests/create_sysconfig.pp
+++ b/manifests/create_sysconfig.pp
@@ -12,11 +12,13 @@ define xrootd::create_sysconfig (
 
   $exports = $xrootd::config::exports,
 
-  $daemon_corefile_limit = $xrootd::config::daemon_corefile_limit
+  $daemon_corefile_limit = $xrootd::config::daemon_corefile_limit,
+  $enable_hdfs = false,
+  $java_home = undef,
 ) {
   include xrootd::config
 
-  file {"$filename":
+  file {$filename:
     ensure  => file,
     owner   => $xrootd_user,
     group   => $xrootd_group,


### PR DESCRIPTION
added explicit parameters (enable_hdfs,java_home) for hdfs as they will not be resolved in Puppet 4.
It seems that Puppet 4 is more strict as to what variables are accessible within templates, probably worth making sure that all of them are defined in the manifest.

Second PR for puppet-dmlite is incoming.
