### PR TITLE
Drop explicit configuration parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,19 @@
-2017-08-23 Andrea Manzi  <andrea.manzi@cern.ch>
-        * update fetchcrl dependency
-2017-07-07 Andrea Manzi  <andrea.manzi@cern.ch>
-        * change how certs are managed to restart Xrootd services if they change
+2016-10-31 Xavier Mol <xavier.mol@kit.edu>
+  * Make the module agnostic towards the numerous xrootd parameters.
+2016-08-23 Andrea Manzi  <andrea.manzi@cern.ch>
+  * update fetchcrl dependency
+2016-07-07 Andrea Manzi  <andrea.manzi@cern.ch>
+  * change how certs are managed to restart Xrootd services if they change
 2016-05-31 Frederic Schaer  <frederic.schaer@cea.fr>
-        * completed support for CentOS7
-        * xrootd service restarted if certificate updated
+  * completed support for CentOS7
+  * xrootd service restarted if certificate updated
 2016-01-18 Frederic Schaer  <frederic.schaer@cea.fr>
-    	* Puppet 4 support
+  * Puppet 4 support
 2015-12-10 Andrea Manzi <andrea.manzi@cern.ch>
-        * added oss.statlib var
-        * added cms.cidtag var
+  * added oss.statlib var
+  * added cms.cidtag var
 2015-09-15  Gerard Bernabeu <gerard1@fnal.gov>
-        * Added some more config variables
+  * Added some more config variables
 	* instances_options now have -k fifo like default xrootd RPM
 	* xrootd_instances_options array fixed and idented template content
 	* all.manager converted in an array

--- a/README.md
+++ b/README.md
@@ -1,9 +1,113 @@
-## puppet-xrootd module
+# puppet-xrootd module
 [![Puppet Forge](http://img.shields.io/puppetforge/v/lcgdm/xrootd.svg)](https://forge.puppetlabs.com/lcgdm/xrootd)
 [![Build Status](https://travis-ci.org/cern-it-sdc-id/puppet-xrootd.svg?branch=master)]([https://travis-ci.org/cern-it-sdc-id/puppet-xrootd.svg)
 
-
 This is the puppet-xrootd module, it configures the Xrootd server and it's a dependency for the configuration of Data Management components developed at CERN , IT-SDC-ID section
+
+### Usage
+
+Including the `xrootd` class for a node will install the 'xrootd' package,
+ensure that a couple of directories, e.g. for configuration files, exist and
+try to start the xrootd and cmsd services.
+
+Just applying the `xrootd` class will not give you the full flexibility
+for the confiruation management. There are five additional resource types
+defined, which may be utilised to generate more sophisticated configuration
+files (see [Resource types](#resource-types)).
+
+There is _no_ support for any kind of plugin management with this module.
+
+#### Parameters
+
+* `xrootd::xrootd_instances`, `xrootd::cmsd_instances`: 
+Used to create Puppet Service resource types for all the xrootd and cmsd
+instances with EL7 installations (_work-in-progress_).
+
+* `xrootd::config::xrootd_user`, -`xrootd_group`:
+Defines user and group name for the xrootd service.
+* `xrootd::config::configdir`:
+The directory where xrootd will find its configuration files.
+* `xrootd::config::logdir`:
+The directory where xrootd is supposed to write its logfiles to.
+* `xrootd::config::spooldir`:
+The spool directory for xrootd activity.
+* `xrootd::config::all_pidpath`:
+Here xrootd will keep information about the pids and environmental settings
+of its independent processes.
+* `xrootd::config::grid_security`:
+Here xrootd will search for grid security related certificate files.
+
+* `xrootd::service::certificate`:
+Where to find the host certificate file.
+* `xrootd::service::key`:
+Where to find the host key file.
+
+#### Resource types
+
+##### `create_authfile`
+Creates the authfile for xrootd. The sole parameter `entries` must be a list,
+which elements are put into the file verbatim.
+
+##### `create_config`
+Create a cfg file for xrootd. Conditional statements are _not_ supported.
+Instead, one should define a seperate cfg file for each daemon. That is,
+every conditional configuration should be met with a split into seperate
+cfg files for individual daemons.
+
+There are three parameters to this resource type:
+`xrootd::create_config::setenv`, `xrootd::create_config::set` and
+`xrootd::create_config::params`. All of them are simple hashes, where the
+key-value pairs will be written as they are into the destination file.
+Settings from the `setenv` hash will be prefixed with 'setenv', likewise
+those of the `set` hash will be prefixed with 'set'. In case a xrootd
+parameter needs to be repeated in the configuration file, use a list as value
+to the same key. For example, in order to set the local and the meta manager,
+the `params` hash could look like this:
+
+```ruby
+{ 'all.manager' => ['my_manager', 'meta my_meta_manager'] }
+```
+
+##### `create_digauthfile`
+Generate the `digauthfile` for the supplied `host` and `group`.
+
+##### `create_sysconfig`
+The sysconfig file is particularly important to configure several
+different xrootd and cmsd instances, by means of...
+* `xrootd::create_sysconfig::xrootd_instances_options`,
+* `xrootd::create_sysconfig::cmsd_instances_options`,
+* `xrootd::create_sysconfig::purd_instances_options` and
+* `xrootd::create_sysconfig::xfrd_instances_options`.
+
+All of these must be a hash, where the key can be 'default' or any other
+string that will be used as the name for the instance. Subsequently,
+the value to each key is the string of command line arguments of the
+respective daemons.
+
+Other self-explanatory parameters this resource type supports are...
+* `xrootd::create_sysconfig::exports`
+* `xrootd::create_sysconfig::daemon_corefile_limit`,
+* `xrootd::create_sysconfig::enable_hdfs` and finally
+* `xrootd::create_sysconfig::java_home`.
+
+##### `create_systemd`
+Create 'override' files in the systemd hierarchy. Supported parameters are...
+* `xrootd::create_systemd::xrootd_user`,
+* `xrootd::create_systemd::xrootd_group`,
+* `xrootd::create_systemd::exports`,
+* `xrootd::create_systemd::daemon_corefile_limit`,
+* `xrootd::create_systemd::enable_hdfs` and
+* `xrootd::create_systemd::java_home`.
+
+All of which have been explained before at least nonce.
+
+### Requirements
+
+This module does _not_ ensure that the xrootd package for installation can
+be found. Administrators have to prepare the environment appropriately!
+
+This module has a build-in dependency on a Puppet module 'fetchcrl',
+which administrators must ensure is defined.
 
 ### License
 ASL 2.0

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,14 +27,8 @@ class xrootd::config (
     group  => $xrootd_group,
   }
 
-  file { [$configdir, $logdir, $all_pidpath]:
+  file { [$configdir, $logdir, $spooldir, $all_pidpath]:
     ensure => directory,
   }
   
-  file { $spooldir:
-    owner  => 'daemon',
-    group  => 'daemon',
-    ensure => directory,
-  }
-
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,11 @@ class xrootd::config (
     refreshonly => true,
   }
   
+  group { $xrootd_group: } ->
+  user { $xrootd_user: 
+    gid => $xrootd_group,
+  }
+  
   File {
     owner  => $xrootd_user,
     group  => $xrootd_group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,10 +24,16 @@ class xrootd::config (
   
   File {
     owner  => $xrootd_user,
-    group  => $xrootd_group
+    group  => $xrootd_group,
   }
 
-  file { [$configdir, $logdir, $spooldir, $all_pidpath]:
+  file { [$configdir, $logdir, $all_pidpath]:
+    ensure => directory,
+  }
+  
+  file { $spooldir:
+    owner  => 'daemon',
+    group  => 'daemon',
     ensure => directory,
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,56 +1,34 @@
 class xrootd::config (
-
   $xrootd_user = $xrootd::params::xrootd_user,
   $xrootd_group = $xrootd::params::xrootd_group,
-
   $configdir = $xrootd::params::configdir,
   $logdir = $xrootd::params::logdir,
   $spooldir = $xrootd::params::spooldir,
   $all_pidpath = $xrootd::params::all_pidpath,
-
+  $grid_security = $xrootd::params::grid_security,
 ) inherits xrootd::params {
-
+  
+  # Rely on this class to be known to Puppet in some way.
   include fetchcrl
-
-  exec {"run-fetchcrl-atleastonce":
+  
+  exec {'run-fetchcrl-atleastonce':
     path    => "/bin:/usr/bin:/sbin:/usr/sbin",
     command => "fetch-crl",
-    unless  => "ls /etc/grid-security/certificates/*.r0"
+    unless  => "ls ${grid_security}/certificates/*.r0"
   }
- 
-  exec {
-    'systemctl-daemon-reload':
-      command => '/usr/bin/systemctl daemon-reload',
-      refreshonly => true,
+  
+  exec {'systemctl-daemon-reload':
+    command     => '/usr/bin/systemctl daemon-reload',
+    refreshonly => true,
   }
-
-  if $::architecture == "x86_64" {
-    $xrdlibdir = "lib64"
-  } else {
-    $xrdlibdir = "lib"
-  }
-
-  file {$configdir:
-    ensure	=> directory,
+  
+  File {
     owner  => $xrootd_user,
     group  => $xrootd_group
   }
 
-  file {$logdir:
+  file { [$configdir, $logdir, $spooldir, $all_pidpath]:
     ensure => directory,
-    owner  => $xrootd_user,
-    group  => $xrootd_group
   }
 
-  file {$spooldir:
-   ensure => directory,
-   owner  => $xrootd_user,
-   group  => $xrootd_group
-  }
-
-  file {$all_pidpath:
-   ensure => directory,
-   owner  => $xrootd_user,
-   group  => $xrootd_group
-  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,11 +17,6 @@ class xrootd::config (
     unless  => "ls ${grid_security}/certificates/*.r0"
   }
   
-  exec {'systemctl-daemon-reload':
-    command     => '/usr/bin/systemctl daemon-reload',
-    refreshonly => true,
-  }
-  
   group { $xrootd_group: } ->
   user { $xrootd_user: 
     gid => $xrootd_group,

--- a/manifests/create_authfile.pp
+++ b/manifests/create_authfile.pp
@@ -1,15 +1,10 @@
 define xrootd::create_authfile (
-  $filename = $title,
-  $template = $xrootd::config::authfile_template,
   $entries,
 ) {
-  include xrootd::config
-
-  file {$filename:
-    ensure  => file,
-    owner   => $::xrootd_user,
-    group   => $::xrootd_group,
-    content => template($template)
+  require xrootd::config
+  
+  file {$title:
+    content => template($xrootd::config::authfile_template)
   }
 
 }

--- a/manifests/create_config.pp
+++ b/manifests/create_config.pp
@@ -1,69 +1,12 @@
 define xrootd::create_config (
-  $filename = $title,
-  $template = $xrootd::config::configfile_template,
-
-  $configdir = $xrootd::config::configdir,
-
-  $xrootd_user = $xrootd::config::xrootd_user,
-  $xrootd_group = $xrootd::config::xrootd_group,
-
-  # sets 'daemon.trace all' for ofs,xrd,cms,oss
-  $xrd_debug = $xrootd::config::xrd_debug,
-
-  $all_adminpath = $xrootd::config::all_adminpath,
-  $all_pidpath = $xrootd::config::all_pidpath,
-  # all.role for exec xrootd/cmsd
-  $xrd_allrole = $xrootd::config::xrd_allrole,
-  $xrd_allrole_list = $xrootd::config::xrd_allrole_list,
-  $cmsd_allrole = $xrootd::config::cmsd_allrole,
-  $all_export = $xrootd::config::all_export,
-  $all_manager = $xrootd::config::all_manager,
-  $all_sitename = $xrootd::config::all_sitename,
-
-  $xrootd_redirect = $xrootd::config::xrootd_redirect,
-  $xrootd_export = $xrootd::config::xrootd_export,
-  $xrootd_seclib = $xrootd::config::xrootd_seclib,
-  $xrootd_async = $xrootd::config::xrootd_async,
-
-  $xrd_port = $xrootd::config::xrd_port,
-  $xrd_network = $xrootd::config::xrd_network,
-
-  $acc_authdb = $xrootd::config::acc_authdb,
-
-  $ofs_authlib = $xrootd::config::ofs_authlib,
-  $ofs_authorize = $xrootd::config::ofs_authorize,
-  $ofs_persist = $xrootd::config::ofs_persist,
-  # ofs.osslib for exec xrootd/cmsd
-  $xrd_ofsosslib = $xrootd::config::xrd_ofsosslib,
-  $cmsd_ofsosslib = $xrootd::config::cmsd_ofsosslib,
-  $cms_allow = $xrootd::config::cms_allow,
-  $cms_delay = $xrootd::config::cms_delay,
-  $cms_fxhold = $xrootd::config::cms_fxhold,
-  $cms_sched = $xrootd::config::cms_sched,
-  $cms_ping = $xrootd::config::cms_ping,
-  $cms_cidtag = $xrootd::config::cms_cidtag,
-  $xrd_sched = $xrootd::config::xrd_sched,
-  $ofs_cmslib = $xrootd::config::ofs_cmslib,
-  $ofs_forward = $xrootd::config::ofs_forward,
-  $ofs_tpc = $xrootd::config::ofs_tpc,
-  $oss_localroot = $xrootd::config::oss_localroot,
-  $oss_defaults = $xrootd::config::oss_defaults,
-  $osscachepath = $xrootd::config::osscachepath,
-  $oss_usage = $xrootd::config::oss_usage,
-  $oss_namelib = $xrootd::config::oss_namelib,
-  $oss_statlib = $xrootd::config::oss_statlib,
-
-  $sec_protocol = $xrootd::config::sec_protocol,
-
-  $pss_origin = $xrootd::config::pss_origin
+  $setenv = false,
+  $set = false,
+  $params = false,
 ) {
-  include xrootd::config
-
-  file {$filename:
-    ensure  => file,
-    owner   => $xrootd_user,
-    group   => $xrootd_group,
-    content => template($template)
+  require xrootd::config
+  
+  file {$title:
+    content => template($xrootd::config::configfile_template)
   }
 
 }

--- a/manifests/create_digauthfile.pp
+++ b/manifests/create_digauthfile.pp
@@ -1,15 +1,11 @@
 define xrootd::create_digauthfile (
-  $filename = $title,
   $template = $xrootd::config::digauthfile_template,
   $host,
   $group,
 ) {
-  include xrootd::config
+  require xrootd::config
 
-  file {$filename:
-    ensure  => file,
-    owner   => $::xrootd_user,
-    group   => $::xrootd_group,
+  file {$title:
     content => template($template)
   }
 

--- a/manifests/create_digauthfile.pp
+++ b/manifests/create_digauthfile.pp
@@ -1,12 +1,11 @@
 define xrootd::create_digauthfile (
-  $template = $xrootd::config::digauthfile_template,
   $host,
   $group,
 ) {
   require xrootd::config
 
   file {$title:
-    content => template($template)
+    content => template($xrootd::config::digauthfile_template)
   }
 
 }

--- a/manifests/create_sysconfig.pp
+++ b/manifests/create_sysconfig.pp
@@ -1,28 +1,19 @@
 define xrootd::create_sysconfig (
-  $filename = $title,
-  $template = $xrootd::config::sysconfigfile_template,
+  $xrootd_instances_options = $xrootd::params::xrootd_instances_options,
+  $cmsd_instances_options = $xrootd::params::cmsd_instances_options,
+  $purd_instances_options = $xrootd::params::purd_instances_options,
+  $xfrd_instances_options = $xrootd::params::xfrd_instances_options,
 
-  $xrootd_user = $xrootd::config::xrootd_user,
-  $xrootd_group = $xrootd::config::xrootd_group,
+  $exports = $xrootd::params::exports,
 
-  $xrootd_instances_options = $xrootd::config::xrootd_instances_options,
-  $cmsd_instances_options = $xrootd::config::cmsd_instances_options,
-  $purd_instances_options = $xrootd::config::purd_instances_options,
-  $xfrd_instances_options = $xrootd::config::xfrd_instances_options,
-
-  $exports = $xrootd::config::exports,
-
-  $daemon_corefile_limit = $xrootd::config::daemon_corefile_limit,
+  $daemon_corefile_limit = $xrootd::params::daemon_corefile_limit,
   $enable_hdfs = false,
   $java_home = undef,
 ) {
-  include xrootd::config
+  require xrootd::config
 
-  file {$filename:
-    ensure  => file,
-    owner   => $xrootd_user,
-    group   => $xrootd_group,
-    content => template($template)
+  file {$title:
+    content => template($xrootd::params::sysconfigfile_template)
   }
 
 }

--- a/manifests/create_sysconfig.pp
+++ b/manifests/create_sysconfig.pp
@@ -1,6 +1,6 @@
 define xrootd::create_sysconfig (
-  $xrootd_user = $xrootd::params::xrootd_user,
-  $xrootd_group = $xrootd::params::xrootd_group,
+  $xrootd_user = $xrootd::config::xrootd_user,
+  $xrootd_group = $xrootd::config::xrootd_group,
   $xrootd_instances_options = $xrootd::params::xrootd_instances_options,
   $cmsd_instances_options = $xrootd::params::cmsd_instances_options,
   $purd_instances_options = $xrootd::params::purd_instances_options,

--- a/manifests/create_sysconfig.pp
+++ b/manifests/create_sysconfig.pp
@@ -1,4 +1,6 @@
 define xrootd::create_sysconfig (
+  $xrootd_user = $xrootd::params::xrootd_user,
+  $xrootd_group = $xrootd::params::xrootd_group,
   $xrootd_instances_options = $xrootd::params::xrootd_instances_options,
   $cmsd_instances_options = $xrootd::params::cmsd_instances_options,
   $purd_instances_options = $xrootd::params::purd_instances_options,

--- a/manifests/create_systemd.pp
+++ b/manifests/create_systemd.pp
@@ -1,18 +1,15 @@
 define xrootd::create_systemd (
-  $filename = $title,
-  $xrootd_user = $xrootd::config::xrootd_user,
-  $xrootd_group = $xrootd::config::xrootd_group,
-  $exports = $xrootd::config::exports,
-  $daemon_corefile_limit = $xrootd::config::daemon_corefile_limit
+  $exports = $xrootd::params::exports,
+  $daemon_corefile_limit = $xrootd::params::daemon_corefile_limit,
 ) {
-  include xrootd::config
+  require xrootd::config
 
-  file {"/etc/systemd/system/${filename}.service.d/":
+  file {"/etc/systemd/system/${title}.service.d/":
     ensure => directory,
     owner   => root,
     group   => root,
   } ->
-  file {"/etc/systemd/system/${filename}.service.d/override.conf":
+  file {"/etc/systemd/system/${title}.service.d/override.conf":
     ensure  => file,
     owner   => root,
     group   => root,

--- a/manifests/create_systemd.pp
+++ b/manifests/create_systemd.pp
@@ -1,8 +1,12 @@
 define xrootd::create_systemd (
+  $xrootd_user = $xrootd::config::xrootd_user,
+  $xrootd_group = $xrootd::config::xrootd_group,
   $exports = $xrootd::params::exports,
   $daemon_corefile_limit = $xrootd::params::daemon_corefile_limit,
+  $enable_hdfs = false,
+  $java_home = undef,
 ) {
-  require xrootd::config
+  require xrootd::service
 
   file {"/etc/systemd/system/${title}.service.d/":
     ensure => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,6 @@
 # == Class: xrootd
 #
-# Full description of class xrootd here.
-#
-# === Parameters
-#
-#
-# === Variables
-#
-#
-# === Examples
-#
+# Refer to the README for detailed documentation.
 #
 # === Authors
 #
@@ -20,12 +11,15 @@
 # Copyright 2012 CERN, unless otherwise noted.
 #
 class xrootd (
-) inherits xrootd::params {
+  $xrootd_instances = undef,
+  $cmsd_instances = undef,
+) {
   
-  Class[xrootd::install] -> Class[xrootd::config] -> Class[xrootd::service]
-
-  class{"xrootd::install":}
-  class{"xrootd::config":}
-  class{"xrootd::service":}
+  class{"xrootd::install": } ->
+    class{"xrootd::config": } ->
+      class{"xrootd::service":
+        xrootd_instances => $xrootd_instances,
+        cmsd_instances => $cmsd_instances,
+      }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,9 +1,4 @@
-class xrootd::install (
-) inherits xrootd::params {
-
-  Class[xrootd::install] -> Class[xrootd::config]
-
-    package {"xrootd":
-      ensure => present
-    }
+class xrootd::install () {
+  # Rely on the environment to find this package on its own.
+  package {"xrootd": }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class xrootd::params {
   $authfile_template = "xrootd/authfile_generic.erb"
   $digauthfile = "${configdir}/digauth.cfg"
   $digauthfile_template = "xrootd/digauthfile.erb"
-  $all_adminpath = "/var/spool/xrootd"
   $all_pidpath = "/var/run/xrootd"
   
   # Unlike the other *_instances_options, this is an array of hashes.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,16 +4,16 @@ class xrootd::params {
   $configdir = "/etc/xrootd"
   $logdir = "/var/log/xrootd"
   $spooldir = "/var/spool/xrootd"
-  
-  $sysconfigfile = "/etc/sysconfig/xrootd"
-  $sysconfigfile_template = "xrootd/sysconfig.erb"
-  $configfile = "${configdir}/xrootd.cfg"
-  $configfile_template = "xrootd/xrootd.cfg.erb"
-  $authfile = "${configdir}/auth_file"
-  $authfile_template = "xrootd/authfile_generic.erb"
-  $digauthfile = "${configdir}/digauth.cfg"
-  $digauthfile_template = "xrootd/digauthfile.erb"
   $all_pidpath = "/var/run/xrootd"
+  
+  #$sysconfigfile = "/etc/sysconfig/xrootd"
+  $sysconfigfile_template = "xrootd/sysconfig.erb"
+  #$configfile = "${configdir}/xrootd.cfg"
+  $configfile_template = "xrootd/xrootd.cfg.erb"
+  #$authfile = "${configdir}/auth_file"
+  $authfile_template = "xrootd/authfile_generic.erb"
+  #$digauthfile = "${configdir}/digauth.cfg"
+  $digauthfile_template = "xrootd/digauthfile.erb"
   
   # Unlike the other *_instances_options, this is an array of hashes.
   $xrootd_instances_options = [ {"default" => "-l ${logdir}/xrootd.log -c ${configdir}/xrootd-clustered.cfg -k fifo"} ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,77 +1,32 @@
 class xrootd::params {
-
-    $xrootd_user = "xrootd"
-    $xrootd_group = "xrootd"
-
-    $xrootd_instances_options = [ {"default" => "-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo"} ] #Unlike the other *_instances_options, this xrootd_instances_options is an array of hashes.
-    $cmsd_instances_options = undef # { "default" => "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" } #This is a hash
-    $purd_instances_options = undef # { "default" => "-l /var/log/xrootd/purd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" } #This is a hash
-    $xfrd_instances_options = undef # { "default" => "-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" } #This is a hash
-
-    $exports = undef
-
-    $daemon_corefile_limit = "unlimited"
-
-    $sysconfigfile = "/etc/sysconfig/xrootd"
-    $sysconfigfile_template = "xrootd/sysconfig.erb"
-    $configfile = "/etc/xrootd/xrootd.cfg"
-    $configfile_template = "xrootd/xrootd.cfg.erb"
-    $authfile = "/etc/xrootd/auth_file"
-    $authfile_template = "xrootd/authfile_generic.erb"
-    $digauthfile = "/etc/xrootd/digauth.cfg"
-    $digauthfile_template = "xrootd/digauthfile.erb"
-    $configdir = "/etc/xrootd"
-    $logdir = "/var/log/xrootd"
-    $spooldir = "/var/spool/xrootd"
-
-    # sets 'daemon.trace all' for ofs,xrd,cms,oss
-    $xrd_debug = false
-
-    $all_adminpath = "/var/spool/xrootd"
-    $all_pidpath = "/var/run/xrootd"
-    # all.role for exec xrootd/cmsd
-    $xrd_allrole = "manager"
-    $cmsd_allrole = "server"
-    $all_export = undef
-    $all_manager = undef
-    $all_sitename = undef
-
-    $xrootd_redirect = undef
-    $xrootd_export = undef
-    $xrootd_seclib = undef
-    $xrootd_async = false
-    $xrootd_chksum = undef
-    $xrootd_monitor = undef
-
-    $sec_protocol = [ ] 
-
-    $xrd_port = undef
-    #$xrd_network = "nodnr"
-    $xrd_network = undef
-    $xrd_report = undef
-    $xrd_maxredirectcount = 1
-
-    $acc_authdb = undef
-
-    $ofs_authlib = undef
-    $ofs_authorize = true
-    $ofs_persist = undef
-    # ofs.osslib for exec xrootd/cmsd
-    $xrd_ofsosslib = undef
-    $cmsd_ofsosslib = undef
-    $cms_allow = undef
-    $cms_fxhold = '60s'
-    $cms_delay = undef
-    $cms_sched = undef
-    $cms_ping = undef
-    $cms_cidtag = undef
-    $ofs_cmslib = undef
-    $ofs_forward = undef
-    $ofs_tpc = undef
-    $pss_origin = undef
-    $pss_setopt = undef
-    $oss_statlib = undef
-    $oss_localroot = undef
-    $certificate = '/etc/grid-security/hostcert.pem'
-    $key = '/etc/grid-security/hostkey.pem'
+  $xrootd_user = "xrootd"
+  $xrootd_group = "xrootd"
+  $configdir = "/etc/xrootd"
+  $logdir = "/var/log/xrootd"
+  $spooldir = "/var/spool/xrootd"
+  
+  $sysconfigfile = "/etc/sysconfig/xrootd"
+  $sysconfigfile_template = "xrootd/sysconfig.erb"
+  $configfile = "${configdir}/xrootd.cfg"
+  $configfile_template = "xrootd/xrootd.cfg.erb"
+  $authfile = "${configdir}/auth_file"
+  $authfile_template = "xrootd/authfile_generic.erb"
+  $digauthfile = "${configdir}/digauth.cfg"
+  $digauthfile_template = "xrootd/digauthfile.erb"
+  $all_adminpath = "/var/spool/xrootd"
+  $all_pidpath = "/var/run/xrootd"
+  
+  # Unlike the other *_instances_options, this is an array of hashes.
+  $xrootd_instances_options = [ {"default" => "-l ${logdir}/xrootd.log -c ${configdir}/xrootd-clustered.cfg -k fifo"} ]
+  $cmsd_instances_options = undef # { "default" => "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+  $purd_instances_options = undef # { "default" => "-l /var/log/xrootd/purd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+  $xfrd_instances_options = undef # { "default" => "-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo" }
+  
+  $exports = undef
+  
+  $daemon_corefile_limit = "unlimited"
+  
+  $grid_security = '/etc/grid-security'
+  $certificate = "${grid_security}/hostcert.pem"
+  $key = "${grid_security}/hostkey.pem"
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,58 +1,43 @@
 class xrootd::service (
-    $sysconfigfile = $xrootd::params::sysconfigfile,
-    $configfile = $xrootd::params::configfile,
-    $authfile = undef,
-    $xrootd_instances = undef,
-    $cmsd_instances = undef,
-    $certificate = $xrootd::params::certificate,
-    $key	= $xrootd::params::key,
+  $xrootd_instances,
+  $cmsd_instances,
+  $sysconfigfile = $xrootd::params::sysconfigfile,
+  $configfile = $xrootd::params::configfile,
+  $authfile = $xrootd::params::authfile,
+  $certificate = $xrootd::params::certificate,
+  $key	= $xrootd::params::key,
 ) inherits xrootd::params {
 
-  Class[xrootd::config] -> Class[xrootd::service]
-
-  if $authfile != undef {
-    $files = File[$sysconfigfile, $configfile, $authfile]
-  } else {
-    $files = File[$sysconfigfile, $configfile]
+  Service {
+    ensure    => running,
+    enable    => true,
+    subscribe => File[$certificate,$key],
   }
 
-  $certificates_files = File[$certificate,$key]
-
- if $::operatingsystemmajrelease and ($::operatingsystemmajrelease + 0) >= 7 { 
-
-   if $xrootd_instances == undef {
-	fail("xrootd_instances parameter  should  not be empty")
-   }
-   service {$xrootd_instances:
-     ensure    => running,
-     enable    => true,
-     provider  => systemd,
-     subscribe => $certificates_files,
-   }
-   if $cmsd_instances != undef {
-	service {$cmsd_instances:
-    	 ensure    => running,
-    	 enable    => true,
-	 provider  => systemd,
-	 subscribe => $certificates_files,
-	 require   => Service[$xrootd_instances]
-   	}
-   }
- }
+  if $::osfamily == 'RedHat' and ($::operatingsystemmajrelease + 0) >= 7 { 
+    if $xrootd_instances == undef {
+      fail("xrootd_instances parameter  should  not be empty")
+    }
+    else {
+      service {$xrootd_instances:
+        provider  => systemd,
+      }
+    }
+    
+    if $cmsd_instances != undef {
+      service {$cmsd_instances:
+        provider  => systemd,
+        require   => Service[$xrootd_instances],
+      }
+    }
+  }
   
- else {
-  # Start the services
-  service {'xrootd':
-    ensure    => running,
-    enable    => true,
-    subscribe =>  $certificates_files ,
+  else {
+    # Start the services
+    service {'xrootd': }
+    
+    service {'cmsd':
+      require   => Service['xrootd'],
+    }
   }
-
-  service {'cmsd':
-    ensure    => running,
-    enable    => true,
-    subscribe =>  $certificates_files,
-    require   => Service['xrootd'],
-   }
- }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,6 @@
 class xrootd::service (
   $xrootd_instances,
   $cmsd_instances,
-  $sysconfigfile = $xrootd::params::sysconfigfile,
-  $configfile = $xrootd::params::configfile,
-  $authfile = $xrootd::params::authfile,
   $certificate = $xrootd::params::certificate,
   $key	= $xrootd::params::key,
 ) inherits xrootd::params {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,7 +16,7 @@ class xrootd::service (
 
   if $::osfamily == 'RedHat' and ($::operatingsystemmajrelease + 0) >= 7 { 
     if $xrootd_instances == undef {
-      fail("xrootd_instances parameter  should  not be empty")
+      fail("xrootd_instances parameter should not be empty")
     }
     else {
       service {$xrootd_instances:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,11 @@ class xrootd::service (
   $key	= $xrootd::params::key,
 ) inherits xrootd::params {
 
+  exec {'systemctl-daemon-reload':
+    command     => '/usr/bin/systemctl daemon-reload',
+    refreshonly => true,
+  }
+  
   Service {
     ensure    => running,
     enable    => true,

--- a/templates/override.erb
+++ b/templates/override.erb
@@ -3,15 +3,16 @@ User= <%= @xrootd_user %>
 Group= <%= @xrootd_group %>
 
 <% if @exports -%>
-<% @exports.sort.map do |key,val| -%>
+  <%- @exports.sort.each do |key,val| -%>
 <%= key %>=<%= val %>
-<% end -%>
-<% end -%>
+  <%- end -%>
 
+<% end -%>
 <% if @daemon_corefile_limit -%>
 DAEMON_COREFILE_LIMIT=<%= @daemon_corefile_limit %>
-<% end -%>
 
+<% end -%>
 <% if @enable_hdfs -%>
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<%= @java_home %>/jre/lib/amd64/server/
+
 <% end -%>

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -22,22 +22,25 @@ XROOTD_GROUP=<%= @xrootd_group %>
 #            without whitespaces is valid
 #-------------------------------------------------------------------------------
 <% if @xrootd_instances_options -%>
-<% @xrootd_instances_options.map do |option_type| -%>
-<% option_type.sort.map do |instance, options| -%>
+  <%- @xrootd_instances_options.sort.each do |instance, options| -%>
 XROOTD_<%= instance.upcase %>_OPTIONS="<%= options %>"
-<% end -%><% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <% if @cmsd_instances_options -%>
-<% @cmsd_instances_options.sort.map do |instance, options| -%>
+  <%- @cmsd_instances_options.sort.each do |instance, options| -%>
 CMSD_<%= instance.upcase %>_OPTIONS="<%= options %>"
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <% if @purd_instances_options -%>
-<% @purd_instances_options.sort.map do |instance, options| -%>
+  <%- @purd_instances_options.sort.each do |instance, options| -%>
 PURD_<%= instance.upcase %>_OPTIONS="<%= options %>"
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <% if @xfrd_instances_options -%>
-<% @xfrd_instances_options.sort.map do |instance, options| -%>
+  <%- @xfrd_instances_options.sort.each do |instance, options| -%>
 XFRD_<%= instance.upcase %>_OPTIONS="<%= options %>"
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 
 #-------------------------------------------------------------------------------
 # Names of the instances to be started by default, the case doesn't matter,
@@ -45,31 +48,22 @@ XFRD_<%= instance.upcase %>_OPTIONS="<%= options %>"
 # separator
 #-------------------------------------------------------------------------------
 <% if @xrootd_instances_options -%>
-XROOTD_INSTANCES="<% -%>
-<% @xrootd_instances_options.map do |option_type| -%>
-<% option_type.sort.map do |instance, options| -%>
-  <%= instance -%>
-<% end -%><% end -%>"<% end %>
+XROOTD_INSTANCES="<%= @xrootd_instances_options.keys.sort.join(" ") -%>"
+<% end -%>
 <% if @cmsd_instances_options -%>
-CMSD_INSTANCES="<% -%>
-<% @cmsd_instances_options.sort.map do |instance, options| -%>
-  <%= instance -%>
-<% end -%>"<% end %>
+CMSD_INSTANCES="<%= @cmsd_instances_options.keys.sort.join(" ") -%>"
+<% end %>
 <% if @purd_instances_options -%>
-PURD_INSTANCES="<% -%>
-<% @purd_instances_options.sort.map do |instance, options| -%>
-  <%= instance -%>
-<% end -%>"<% end %>
+PURD_INSTANCES="<%= @purd_instances_options.keys.sort.join(" ") -%>"
+<% end %>
 <% if @xfrd_instances_options -%>
-XFRD_INSTANCES="<% -%>
-<% @xfrd_instances_options.sort.map do |instance, options| -%>
-  <%= instance -%>
-<% end -%>"<% end %>
+XFRD_INSTANCES="<%= @xfrd_instances_options.keys.sort.join(" ") -%>"
+<% end %>
 
 <% if @exports -%>
-<% @exports.sort.map do |key,val| -%>
+  <%- @exports.sort.map do |key,val| -%>
 export <%= key %>=<%= val %>
-<% end -%>
+  <%- end -%>
 <% end -%>
 
 <% if @daemon_corefile_limit -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -1,152 +1,20 @@
+# This file is managed by Puppet. Changes will be undone with the next
+# synchronization.
+
 <% if @setenv -%>
-<% @setenv.sort.each do |key,val| -%>
+  <%- @setenv.sort.each do |key,val| -%>
 setenv <%= key %>=<%= val %>
-<% end -%>
-<% end -%>
-
-<% if @xrd_debug -%>
-ofs.trace all
-xrd.trace all
-cms.trace all
-oss.trace all
-<% else -%>
-#ofs.trace all
-#xrd.trace all
-#cms.trace all
-#oss.trace all
+  <%- end -%>
 <% end -%>
 
-all.adminpath <%= @all_adminpath %>
-all.pidpath <%= @all_pidpath %>
-<% if @all_sitename -%>
-all.sitename <%= @all_sitename %>
-<% end -%>
-<% if @oss_localroot -%>
-oss.localroot <%= @oss_localroot %>
-<% end -%>
-<% if @all_export -%>
-<% @all_export.sort.each do |export| -%>
-all.export <%= File.join(export,"") %>
-<% end -%>
-<% end -%>
-<% if @xrd_network -%>
-xrd.network <%= @xrd_network %>
+<% if @set -%>
+  <%- @set.sort.each do |key,val| -%>
+set <%= key %>=<%= val %>
+  <%- end -%>
 <% end -%>
 
-<% if @oss_localroot -%>
-oss.localroot <%= @oss_localroot %>
-<% end -%>
-
-<% if @xrootd_chksum -%>
-xrootd.chksum <%= @xrootd_chksum %>
-<% end -%>
-<% if @xrootd_monitor -%>
-xrootd.monitor <%= @xrootd_monitor %>
-<% end -%>
-<% if @xrootd_async -%>
-xrootd.async <%= @xrootd_async %>
-<% end -%>
-
-if exec xrootd
-xrootd.seclib <%= @xrootd_seclib %>
-<% if @sec_protocol -%>
-<% @sec_protocol.sort.each do |secprot| -%>
-sec.protocol <%= secprot %>
-<% end -%>
-<% end -%>
-<% if @xrootd_redirect -%>
-xrootd.redirect <%= @xrootd_redirect %>
-<% end -%>
-<% if @xrootd_export -%>
-<% @xrootd_export.sort.each do |export| -%>
-xrootd.export <%= File.join(export,"") %>
-<% end -%>
-<% end -%>
-<% if @xrd_port -%>
-xrd.port <%= @xrd_port %>
-<% end -%>
-<% if @xrd_report -%>
-xrd.report <%= @xrd_report %>
-<% end -%>
-<% if @ofs_cmslib -%>
-ofs.cmslib <%= @ofs_cmslib %>
-<% end -%>
-<% if @xrd_ofsosslib -%>
-ofs.osslib <%= @xrd_ofsosslib %>
-<% end -%>
-<% if @ofs_authlib -%>
-ofs.authlib <%= @ofs_authlib %>
-<% end -%>
-<% if @ofs_authorize -%>
-ofs.authorize
-<% end -%>
-<% if @ofs_forward -%>
-ofs.forward <%= @ofs_forward %>
-<% end -%>
-<% if @ofs_persist -%>
-ofs.persist <%= @ofs_persist %>
-<% end -%>
-<% if @ofs_tpc -%>
-ofs.tpc <%= @ofs_tpc %>
-<% end -%>
-<% if @acc_authdb -%>
-acc.authdb <%= @acc_authdb %>
-<% end -%>
-all.role <%= @xrd_allrole %>
-fi
-
-if exec cmsd
-<% if @oss_statlib -%>
- oss.statlib <%= @oss_statlib %>
-<% else -%>
- <% if @cmsd_ofsosslib -%>
- ofs.osslib <%= @cmsd_ofsosslib %>
- <% end -%>
- <% if @pss_origin -%>
- pss.origin <%= @pss_origin %>
- <% end -%>
- <% if @pss_setopt -%>
- <% @pss_setopt.sort.each do |option| -%>
- pss.setopt <%= option %>
- <% end -%>
- <% end -%>
-<% end -%>
- all.role <%= @cmsd_allrole %>
-<% if @cms_allow -%>
-<% @cms_allow.sort.each do |allow| -%>
- cms.allow <%= allow %>
-<% end -%>
-<% end -%>
-<% if @cms_delay -%>
- cms.delay <%= @cms_delay %>
-<% end -%> 
-<% if @cms_sched -%>
- cms.sched <%= @cms_sched %>
-<% end -%> 
-<% if @cms_fxhold -%>
- cms.fxhold <%= @cms_fxhold %>
-<% end -%>
-<% if @cms_ping -%>
- cms.ping <%= @cms_ping %>
-<% end -%>
-fi
-<% if @cms_cidtag -%>
-cms.cidtag <%= @cms_cidtag %>
-<% end -%>
-
-<% if @all_manager -%>
-<% Array(@all_manager).sort.each do |manager| -%>
-all.manager <%= manager %>
-<% end -%>
-<% end -%>
-
-<% if @specifics -%>
-<%= @specifics %>
-<% end -%>
-
-<% if @acc_authlib -%>
-acc.authlib <%= @acc_authlib %>
-<% end -%>
-<% if @frm_xfr_copycmd -%>
-frm.xfr.copycmd <%= @frm_xfr_copycmd %>
+<% if @params -%>
+  <%- @params.sort.each do |key,val| -%>
+<%= key %>=<%= val %>
+  <%- end -%>
 <% end -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -5,14 +5,14 @@
   <%- @setenv.sort.each do |key,val| -%>
 setenv <%= key %>=<%= val %>
   <%- end -%>
-<% end -%>
 
+<% end -%>
 <% if @set -%>
   <%- @set.sort.each do |key,val| -%>
 set <%= key %>=<%= val %>
   <%- end -%>
-<% end -%>
 
+<% end -%>
 <% if @params -%>
   <%- @params.sort.each do |key,val| -%>
     <%- if val.respond_to? :each -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -17,10 +17,10 @@ set <%= key %>=<%= val %>
   <%- @params.sort.each do |key,val| -%>
     <%- if val.respond_to? :each -%>
       <%- val.each do |v| -%>
-<%= key %>=<%= v %>
+<%= key %> <%= v %>
       <%- end -%>
     <%- else -%>
-<%= key %>=<%= val %>
+<%= key %> <%= val %>
     <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -18,6 +18,7 @@ set <%= key %>=<%= val %>
     <%- if val.respond_to? :each -%>
       <%- val.each do |v| -%>
 <%= key %>=<%= v %>
+      <%- end -%>
     <%- else -%>
 <%= key %>=<%= val %>
     <%- end -%>

--- a/templates/xrootd.cfg.erb
+++ b/templates/xrootd.cfg.erb
@@ -15,6 +15,11 @@ set <%= key %>=<%= val %>
 
 <% if @params -%>
   <%- @params.sort.each do |key,val| -%>
+    <%- if val.respond_to? :each -%>
+      <%- val.each do |v| -%>
+<%= key %>=<%= v %>
+    <%- else -%>
 <%= key %>=<%= val %>
+    <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
Accepting the pull request will make puppet-xrootd agnostic towards the individual xrootd configuration parameters. Ie. it is neither possible nor advised to have all the different xrootd configuration parameters acknowledged by the templates generating the configuration file. The administrators can submit any setting and it will be put into the destination file without further evaluation. As a consequence, the script-like behaviour of typical xrootd configuration files with conditional expressions is not supported. Instead, one should manage separate configuration files, e.g. one for the default xrootd daemon, another for the default cmsd.