### PR TITLE
Set dependency to fetchcrl::install for the fetchcrl command.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,8 @@ class xrootd::config (
   exec {"run-fetchcrl-atleastonce":
     path    => "/bin:/usr/bin:/sbin:/usr/sbin",
     command => "fetch-crl",
-    unless  => "ls /etc/grid-security/certificates/*.r0"
+    unless  => "ls /etc/grid-security/certificates/*.r0",
+    require => Class["Fetchcrl::Install"]
   }
  
   exec {


### PR DESCRIPTION
On a clean environment, fetch-crl execution fails as the command
is not yet available in the system. Setting a requirement for
fetchcrl::install class solves the issue.